### PR TITLE
Center `preview` on phone screen + fix layout shift

### DIFF
--- a/view/preview/index.css
+++ b/view/preview/index.css
@@ -7,6 +7,21 @@
   pointer-events: none;
 }
 
+@media (orientation: portrait) {
+  .preview__graphics {
+    /* Align the logo to the vertical center in browsers without `svh` unit support */
+    margin-top: -15vh;
+    height: 300vh;
+  }
+
+  @supports (height: 1svh) {
+    .preview__graphics {
+      margin-top: 0;
+      height: 300svh;
+    }
+  }
+}
+
 .preview__graphics circle {
   transform: translateZ(0);
 }
@@ -17,7 +32,7 @@
   opacity: 0;
   animation-name: fadeIn;
   animation-duration: .9s;
-  animation-delay: .1s; /* Prevent layout shift on page loading */
+  animation-delay: .15s; /* Prevent layout shift on page loading */
   animation-timing-function: cubic-bezier(0, 0.75, 0.25, 1);
   animation-fill-mode: forwards;
 }

--- a/view/preview/index.css
+++ b/view/preview/index.css
@@ -12,11 +12,14 @@
 }
 
 .preview__scroller {
-  transform: scale(0.2) translateZ(0);
+  transform: translateZ(0);
   transform-origin: 50% 50vh;
   opacity: 0;
-  animation: fadeIn 1s cubic-bezier(0, 0.75, 0.25, 1) forwards;
-  top: 0;
+  animation-name: fadeIn;
+  animation-duration: .9s;
+  animation-delay: .1s; /* Prevent layout shift on page loading */
+  animation-timing-function: cubic-bezier(0, 0.75, 0.25, 1);
+  animation-fill-mode: forwards;
 }
 
 @keyframes fadeIn{


### PR DESCRIPTION
- [x] Fix .preview layout shift on page refresh
- [x] Align the logo to the center of the phone screen